### PR TITLE
Fix Urlbase for ng generate command

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
       "es2017",
       "dom"
     ],
-    "baseUrl": "./",
+    "baseUrl": "./src/",
     "paths": {
       "@angular/*": ["../node_modules/@angular/*"]
     }


### PR DESCRIPTION
### Add the baseUrl to tsconfig 
ng generate componente x --> Fixed problem. baseUrl defined

**Refe:** 
#123 
https://www.typescriptlang.org/docs/handbook/module-resolution.html

{
  "compileOnSave": false,
  "compilerOptions": {
    "outDir": "./dist/out-tsc",
    "sourceMap": true,
    "declaration": false,
    "moduleResolution": "node",
    "emitDecoratorMetadata": true,
    "experimentalDecorators": true,
    "target": "es5",
    "types": [ "node" ],
    "typeRoots": [
      "node_modules/@types"
    ],
    "lib": [
      "es2017",
      "dom"
    ],
    "baseUrl": "./",
    "paths": {
      "@angular/*": ["../node_modules/@angular/*"]
    }
  }
}

