### PR TITLE
Loan Card numbers to Roboto Font

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Misc:
+- Use Roboto font for number display
+
 ### Fix:
 - Fix bug when view card-loan type visibility
 - Fix bug when approve contract checkbox visibility

--- a/src/app/shared/conversion-graphic/body-list/body-list.component.scss
+++ b/src/app/shared/conversion-graphic/body-list/body-list.component.scss
@@ -9,7 +9,7 @@
   border-bottom: 1px solid black;
   div{
     flex: 1;
-    @extend %roboto-bold;
+    @extend %roboto-black;
     &:nth-child(1){
       text-align: left;
       font-size: 26px;

--- a/src/app/shared/conversion-graphic/body-list/body-list.component.scss
+++ b/src/app/shared/conversion-graphic/body-list/body-list.component.scss
@@ -9,7 +9,7 @@
   border-bottom: 1px solid black;
   div{
     flex: 1;
-    @extend %font-bold;
+    @extend %roboto-bold;
     &:nth-child(1){
       text-align: left;
       font-size: 26px;

--- a/src/app/shared/loan-avatar/loan-avatar.component.scss
+++ b/src/app/shared/loan-avatar/loan-avatar.component.scss
@@ -35,7 +35,7 @@
     .title{
       line-height: 1.4;
       font-size: 16px;
-      @extend %font-medium;
+      @extend %roboto-medium;
     }
     .subtitle{
       line-height: 1.4;

--- a/src/app/shared/loan-avatar/loan-avatar.component.scss
+++ b/src/app/shared/loan-avatar/loan-avatar.component.scss
@@ -35,7 +35,7 @@
     .title{
       line-height: 1.4;
       font-size: 16px;
-      @extend %roboto-medium;
+      @extend %font-medium;
     }
     .subtitle{
       line-height: 1.4;

--- a/src/app/shared/loan-card/loan-card.component.scss
+++ b/src/app/shared/loan-card/loan-card.component.scss
@@ -50,7 +50,6 @@
       @extend %propiety-title;
     }
     .paragraph{
-      @extend %roboto-medium;
       @extend %propiety-subtitle;
     }
     .btn{
@@ -91,7 +90,7 @@
   border-bottom: 1px solid black;
   div{
     flex: 1;
-    @extend %roboto-bold;
+    @extend %roboto-black;
     &:nth-child(1){
       text-align: left;
       font-size: 24px;

--- a/src/app/shared/loan-card/loan-card.component.scss
+++ b/src/app/shared/loan-card/loan-card.component.scss
@@ -50,6 +50,7 @@
       @extend %propiety-title;
     }
     .paragraph{
+      @extend %roboto-medium;
       @extend %propiety-subtitle;
     }
     .btn{
@@ -90,10 +91,10 @@
   border-bottom: 1px solid black;
   div{
     flex: 1;
-    @extend %font-bold;
+    @extend %roboto-bold;
     &:nth-child(1){
       text-align: left;
-      font-size: 26px;
+      font-size: 24px;
     }
     &:nth-child(2){
       display: flex;
@@ -103,7 +104,7 @@
     &:nth-child(3){
       color: $primary;
       text-align: right;
-      font-size: 26px;
+      font-size: 24px;
     }
   }
 }

--- a/src/app/shared/risk-indicator/risk-indicator.component.ts
+++ b/src/app/shared/risk-indicator/risk-indicator.component.ts
@@ -9,7 +9,7 @@ import { RiskService, Level } from '../../services/risk.service';
 })
 export class RiskIndicatorComponent implements OnInit {
   @Input() loan: Loan;
-  @Input() color = 'gray0';
+  @Input() color = 'gray3';
 
   icon: string;
   tooltip: string;

--- a/src/app/shared/risk-indicator/risk-indicator.component.ts
+++ b/src/app/shared/risk-indicator/risk-indicator.component.ts
@@ -9,7 +9,7 @@ import { RiskService, Level } from '../../services/risk.service';
 })
 export class RiskIndicatorComponent implements OnInit {
   @Input() loan: Loan;
-  @Input() color = 'gray3';
+  @Input() color = 'gray5';
 
   icon: string;
   tooltip: string;

--- a/src/app/views/loan-detail/loan-detail.component.html
+++ b/src/app/views/loan-detail/loan-detail.component.html
@@ -19,7 +19,7 @@
     <div class="left">
       <div class="avatar-information">
         <div class="flex-item">
-          <app-loan-avatar [loan]=loan [short]=false></app-loan-avatar>
+          <app-loan-avatar [loan]=loan [short]=true></app-loan-avatar>
         </div>
         <div class="flex-item">
           <app-avatar-title [loan]=loan></app-avatar-title>

--- a/src/app/views/loan-detail/loan-detail.component.html
+++ b/src/app/views/loan-detail/loan-detail.component.html
@@ -16,7 +16,6 @@
   </div>
 
   <div class="loan-description flex-container">
-
     <div class="left">
       <div class="avatar-information">
         <div class="flex-item">

--- a/src/app/views/loan-detail/loan-detail.component.scss
+++ b/src/app/views/loan-detail/loan-detail.component.scss
@@ -108,8 +108,6 @@
 @media (min-width: 992px) { 
   .loan-detail{
     width: 970px;
-    // padding-right: 15px;
-    // padding-left: 15px;
     margin-left: auto;
     margin-right: auto;
   }
@@ -142,6 +140,18 @@
 @media (min-width: 1200px) { 
   .loan-detail{
     width: 1170px;
+  }
+  .loan-description{
+    &.flex-container{
+      .left{
+        .avatar-information{
+          .flex-item{
+            &:nth-child(1){ width: 80%; }
+            &:nth-child(2){ width: 20%; }
+          }
+        }
+      }
+    }
   }
 }
 

--- a/src/app/views/loan-detail/loan-detail.component.scss
+++ b/src/app/views/loan-detail/loan-detail.component.scss
@@ -146,8 +146,8 @@
       .left{
         .avatar-information{
           .flex-item{
-            &:nth-child(1){ width: 80%; }
-            &:nth-child(2){ width: 20%; }
+            &:nth-child(1){ width: 75%; }
+            &:nth-child(2){ width: 25%; }
           }
         }
       }


### PR DESCRIPTION
### Change Raleway font for numbers to Roboto
-Impreve numbers view
-This may help to fix visual distortion in numbers with raleways

**Branch:** font-roboto
**Refe:** #96 

![rcn-loans--font-01](https://user-images.githubusercontent.com/12101846/45504539-8ae7f180-b760-11e8-8552-869e41b0d5ca.jpg)
